### PR TITLE
Add buffet menu webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>한식 뷔페 메뉴</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f8f8f8;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 800px;
+            margin: 20px auto;
+            background-color: #fff;
+            padding: 20px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            text-align: center;
+        }
+        ul {
+            list-style: none;
+            padding: 0;
+        }
+        li {
+            margin: 10px 0;
+        }
+        a {
+            color: #0066cc;
+            text-decoration: none;
+        }
+        #announcement {
+            margin-top: 40px;
+            padding: 15px;
+            border: 1px solid #ccc;
+            background-color: #fafafa;
+        }
+        #update-form {
+            margin-top: 20px;
+        }
+        #update-form textarea {
+            width: 100%;
+            height: 80px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>오늘의 한식 뷔페 메뉴</h1>
+        <ul>
+            <li><a href="https://example.com/menu1" target="_blank">서울 맛집 메뉴</a></li>
+            <li><a href="https://example.com/menu2" target="_blank">부산 맛집 메뉴</a></li>
+            <li><a href="https://example.com/menu3" target="_blank">대전 맛집 메뉴</a></li>
+            <li><a href="https://example.com/menu4" target="_blank">광주 맛집 메뉴</a></li>
+        </ul>
+        <div id="announcement"></div>
+        <div id="update-form">
+            <textarea id="announcement-text" placeholder="알림 내용을 입력하세요..."></textarea>
+            <button id="save-btn">저장</button>
+        </div>
+    </div>
+
+    <script>
+        const announcementDiv = document.getElementById('announcement');
+        const announcementText = document.getElementById('announcement-text');
+        const saveBtn = document.getElementById('save-btn');
+
+        function loadAnnouncement() {
+            const stored = localStorage.getItem('announcement');
+            if (stored) {
+                announcementDiv.textContent = stored;
+            }
+        }
+
+        saveBtn.addEventListener('click', () => {
+            const text = announcementText.value;
+            announcementDiv.textContent = text;
+            localStorage.setItem('announcement', text);
+            announcementText.value = '';
+        });
+
+        loadAnnouncement();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` to link to four buffet menu pages
- implement announcement board that saves messages locally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847c58a821083288ba92e26a7bbb2dc